### PR TITLE
Adopt the latest iOS beta

### DIFF
--- a/compositional-layouts-kit/Application Flow VCs/ViewController.swift
+++ b/compositional-layouts-kit/Application Flow VCs/ViewController.swift
@@ -156,7 +156,7 @@ extension ViewController {
     }
     
     func snapshotForCurrentState() -> NSDiffableDataSourceSnapshot<Section, OutlineItem> {
-        let snapshot = NSDiffableDataSourceSnapshot<Section, OutlineItem>()
+        var snapshot = NSDiffableDataSourceSnapshot<Section, OutlineItem>()
         snapshot.appendSections([Section.main])
         func addItems(_ menuItem: OutlineItem) {
             snapshot.appendItems([menuItem])

--- a/compositional-layouts-kit/Compositional Layouts VCs/BannerTileGridViewController.swift
+++ b/compositional-layouts-kit/Compositional Layouts VCs/BannerTileGridViewController.swift
@@ -88,7 +88,7 @@ extension BanerTileGridViewController {
         }
         
         // Initial data
-        let snapshot = NSDiffableDataSourceSnapshot<Section, ImageModel>()
+        var snapshot = NSDiffableDataSourceSnapshot<Section, ImageModel>()
         snapshot.appendSections([.main])
         
         func produceImage() -> UIImage {

--- a/compositional-layouts-kit/Compositional Layouts VCs/GalleryViewController.swift
+++ b/compositional-layouts-kit/Compositional Layouts VCs/GalleryViewController.swift
@@ -80,7 +80,7 @@ extension GalleryViewController {
         }
         
         // initial data
-        let snapshot = NSDiffableDataSourceSnapshot<Section, ImageModel>()
+        var snapshot = NSDiffableDataSourceSnapshot<Section, ImageModel>()
         snapshot.appendSections([.main])
 
         func produceImage() -> UIImage {

--- a/compositional-layouts-kit/Compositional Layouts VCs/GroupGridViewController.swift
+++ b/compositional-layouts-kit/Compositional Layouts VCs/GroupGridViewController.swift
@@ -111,7 +111,7 @@ extension GroupGridViewController {
         }
         
         // Initial data
-        let snapshot = NSDiffableDataSourceSnapshot<Section, ImageModel>()
+        var snapshot = NSDiffableDataSourceSnapshot<Section, ImageModel>()
         snapshot.appendSections([.main])
         
         func produceImage() -> UIImage {

--- a/compositional-layouts-kit/Compositional Layouts VCs/MosaicReduxViewController.swift
+++ b/compositional-layouts-kit/Compositional Layouts VCs/MosaicReduxViewController.swift
@@ -107,7 +107,7 @@ extension MosaicReduxViewController {
         }
         
         // Initial data
-        let snapshot = NSDiffableDataSourceSnapshot<Section, ImageModel>()
+        var snapshot = NSDiffableDataSourceSnapshot<Section, ImageModel>()
         snapshot.appendSections([.main])
         
         func produceImage() -> UIImage {

--- a/compositional-layouts-kit/Compositional Layouts VCs/MosaicViewController.swift
+++ b/compositional-layouts-kit/Compositional Layouts VCs/MosaicViewController.swift
@@ -123,7 +123,7 @@ extension MosaicViewController {
         }
         
         // Initial data
-        let snapshot = NSDiffableDataSourceSnapshot<Section, ImageModel>()
+        var snapshot = NSDiffableDataSourceSnapshot<Section, ImageModel>()
         snapshot.appendSections([.main])
         
         func produceImage() -> UIImage {

--- a/compositional-layouts-kit/Compositional Layouts VCs/PortraitTileGridViewController.swift
+++ b/compositional-layouts-kit/Compositional Layouts VCs/PortraitTileGridViewController.swift
@@ -88,7 +88,7 @@ extension PortraitTileGridViewController {
         }
         
         // Initial data
-        let snapshot = NSDiffableDataSourceSnapshot<Section, ImageModel>()
+        var snapshot = NSDiffableDataSourceSnapshot<Section, ImageModel>()
         snapshot.appendSections([.main])
         
         func produceImage() -> UIImage {

--- a/compositional-layouts-kit/Compositional Layouts VCs/ShowcaseGalleryViewController.swift
+++ b/compositional-layouts-kit/Compositional Layouts VCs/ShowcaseGalleryViewController.swift
@@ -93,7 +93,7 @@ extension ShowcaseGalleryViewController {
         }
         
         // initial data
-        let snapshot = NSDiffableDataSourceSnapshot<Int, ImageModel>()
+        var snapshot = NSDiffableDataSourceSnapshot<Int, ImageModel>()
         var identifierOffset = 0
         let itemsPerSection = 8
         for section in 0..<8 {

--- a/compositional-layouts-kit/Compositional Layouts VCs/TileGalleryViewController.swift
+++ b/compositional-layouts-kit/Compositional Layouts VCs/TileGalleryViewController.swift
@@ -105,7 +105,7 @@ extension TileGalleryViewController {
         }
         
         // Initial data
-        let snapshot = NSDiffableDataSourceSnapshot<Section, ImageModel>()
+        var snapshot = NSDiffableDataSourceSnapshot<Section, ImageModel>()
         snapshot.appendSections([.main])
         
         func produceImage() -> UIImage {

--- a/compositional-layouts-kit/Compositional Layouts VCs/TileGridViewController.swift
+++ b/compositional-layouts-kit/Compositional Layouts VCs/TileGridViewController.swift
@@ -96,7 +96,7 @@ extension TileGridViewController {
         }
         
         // Initial data
-        let snapshot = NSDiffableDataSourceSnapshot<Section, ImageModel>()
+        var snapshot = NSDiffableDataSourceSnapshot<Section, ImageModel>()
         snapshot.appendSections([.main])
         
         func produceImage() -> UIImage {

--- a/compositional-layouts-kit/Compositional Layouts VCs/WaterfallViewController.swift
+++ b/compositional-layouts-kit/Compositional Layouts VCs/WaterfallViewController.swift
@@ -113,7 +113,7 @@ extension WaterfallViewController {
         }
         
         // initial data
-        let snapshot = NSDiffableDataSourceSnapshot<Section, ImageModel>()
+        var snapshot = NSDiffableDataSourceSnapshot<Section, ImageModel>()
         snapshot.appendSections([.main])
         
         func produceImage() -> UIImage {

--- a/compositional-layouts-kit/Supplimentary Views/ItemBadgeSupplementaryViewController.swift
+++ b/compositional-layouts-kit/Supplimentary Views/ItemBadgeSupplementaryViewController.swift
@@ -122,7 +122,7 @@ extension ItemBadgeSupplementaryViewController {
         }
         
         // initial data
-        let snapshot = NSDiffableDataSourceSnapshot<Section, Model>()
+        var snapshot = NSDiffableDataSourceSnapshot<Section, Model>()
         snapshot.appendSections([.main])
         let models = (0..<100).map { Model(title: "\($0)", badgeCount: Int.random(in: 0..<3)) }
         snapshot.appendItems(models)


### PR DESCRIPTION
From beta 6 (current beta), it changes `NSDiffableDataSourceSnapshot` class to struct. So `snapshot` variable should be `var`. 